### PR TITLE
Use underscores in render database names

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,18 +1,18 @@
 databases:
-  - name: data-software-catalogue
-    databaseName: data-software-catalogue
-    user: data-software-catalogue
+  - name: data_software_catalogue
+    databaseName: data_software_catalogue
+    user: data_software_catalogue
 
 services:
   - type: web
-    name: data-software-catalogue
+    name: data_software_catalogue
     env: ruby
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec puma -C config/puma.rb"
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: data-software-catalogue
+          name: data_software_catalogue
           property: connectionString
       - key: RAILS_MASTER_KEY
         sync: false


### PR DESCRIPTION
Initial configuration used hyphens in the database and user names, which is not a valid option.