### PR TITLE
Add dynamic page titles that include controller and action names

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,15 @@
 module ApplicationHelper
+  def page_title(prefix)
+    return prefix if current_page?(root_url)
+
+    [prefix, page_title_suffix].flatten.map(&:titleize).join(' - ')
+  end
+
+  def page_title_suffix
+    return "Organisation #{params[:organisation_id]} Software" if controller_name == 'software_instances' && action_name == 'index'
+    return controller_name if action_name == 'index'
+    return [controller_name, action_name] unless params[:id].present?
+
+    [controller_name, "#{action_name} #{params[:id]}"]
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8">
-    <title>DataSoftwareCatalogue</title>
+    <title><%= page_title('Data Software Catalogue') %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
With this in place, when a user looks in their browser history, they will be able to recognise individual pages. Before this change all pages had the same title.