### PR TITLE
Change organisations to use a tag for urls

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -18,7 +18,7 @@ class OrganisationsController < ApplicationController
     authorize @organisation = Organisation.new(organisation_params)
 
     if organisation.save
-      redirect_to organisation, notice: "Organisation was successfully created."
+      redirect_to organisation_software_path, notice: "Organisation was successfully created."
     else
       render :new, status: :unprocessable_entity
     end
@@ -32,7 +32,7 @@ class OrganisationsController < ApplicationController
   # PATCH/PUT /organisations/1
   def update
     if organisation.update(organisation_params)
-      redirect_to @organisation, notice: "Organisation was successfully updated."
+      redirect_to organisation_software_path, notice: "Organisation was successfully updated."
     else
       render :edit, status: :unprocessable_entity
     end
@@ -46,13 +46,17 @@ class OrganisationsController < ApplicationController
 
 private
 
+  def organisation_software_path
+    organisation_software_instances_path(organisation)
+  end
+
   # Use callbacks to share common setup or constraints between actions.
   def organisation
-    @organisation ||= authorize Organisation.find(params[:id])
+    @organisation ||= authorize Organisation.find_by(tag: params[:id])
   end
 
   # Only allow a list of trusted parameters through.
   def organisation_params
-    params.require(:organisation).permit(:name)
+    params.require(:organisation).permit(:name, :tag)
   end
 end

--- a/app/controllers/software_instances_controller.rb
+++ b/app/controllers/software_instances_controller.rb
@@ -49,7 +49,7 @@ private
 
   def organisation
     @organisation ||= if params[:organisation_id].present?
-                        Organisation.find(params[:organisation_id])
+                        Organisation.find_by!(tag: params[:organisation_id])
                       else
                         software_instance.organisation
                       end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,5 +2,17 @@ class Organisation < ApplicationRecord
   has_many :users
   has_many :software_instances
 
-  validates :name, presence: true
+  validates :name, :tag, presence: true
+  validates(
+    :tag,
+    uniqueness: true,
+    format: {
+      with: /\A[a-zA-Z0-9][\w\-]*[a-zA-Z0-9]\z/,
+      message: 'must not have spaces but can be split with hyphens or underscores'
+    }
+  )
+
+  def to_param
+    tag
+  end
 end

--- a/app/views/organisations/_form.html.erb
+++ b/app/views/organisations/_form.html.erb
@@ -16,6 +16,13 @@
     <%= form.text_field :name, class: "govuk-input" %>
   </div>
 
+  <% unless organisation.persisted? %>
+    <div class="govuk-form-group">
+      <%= form.label :tag, style: "display: block", class: "govuk-label" %>
+      <%= form.text_field :tag, class: "govuk-input" %>
+    </div>
+  <% end %>
+
   <div>
     <%= form.submit class: "govuk-button", data: { module: "govuk-button" } %>
   </div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,5 +7,9 @@ npm install
 bundle exec rake dartsass:build
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate
-bundle exec rake db:seed
+# Production configuration
+# bundle exec rake db:migrate
+# bundle exec rake db:seed
+
+# Temp configuration until database config and seeding sorted
+bundle exec rake db:reset

--- a/db/migrate/20230103161945_add_tag_to_organisations.rb
+++ b/db/migrate/20230103161945_add_tag_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddTagToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :tag, :string
+    add_index :organisations, :tag
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_19_160305) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_03_161945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_19_160305) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "tag"
+    t.index ["tag"], name: "index_organisations_on_tag"
   end
 
   create_table "pg_search_documents", force: :cascade do |t|

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -1,0 +1,96 @@
+GDS:
+  hyphenated_name: government-digital-service
+  name: Government Digital Service
+ONS:
+  hyphenated_name: office-of-national-statistics
+  name: Office for National Statistics
+DVLA:
+  hyphenated_name: driver-and-vehicle-licensing-agency
+  name: Driver and Vehicle Licensing Agency
+CH:
+  hyphenated_name: companies-house
+  name: Companies House
+OS:
+  hyphenated_name: ordnance-survey
+  name: Ordnance Survey
+EA:
+  hyphenated_name: environment-agency
+  name: Environment Agency
+Scot:
+  hyphenated_name: scottish-government
+  name: Scottish Government
+DfE:
+  hyphenated_name: department-for-education
+  name: Department for Education
+DWP:
+  hyphenated_name: department-for-work-and-pensions
+  name: Department for Work and Pensions
+Hackney:
+  hyphenated_name: london-borough-of-hackney
+  name: London Borough of Hackney
+LGA:
+  hyphenated_name: local-government-association
+  name: Local Government Association
+WBerks:
+  hyphenated_name: west-berkshire-council
+  name: West Berkshire Council
+HMRC:
+  hyphenated_name: hm-revenue-customs
+  name: HM Revenue & Customs
+UKHO:
+  hyphenated_name: uk-hydrographic-office
+  name: UK Hydrographic Office
+DIT:
+  hyphenated_name: department-for-international-trade
+  name: Department for International Trade
+WMCA:
+  hyphenated_name: west-midlands-combined-authority
+  name: West Midlands Combined Authority
+TNA:
+  hyphenated_name: the-national-archives
+  name: The National Archives
+MOJ:
+  hyphenated_name: ministry-of-justice
+  name: Ministry of Justice
+TfL:
+  hyphenated_name: transport-for-london
+  name: Transport for London
+UKP:
+  hyphenated_name: uk-police
+  name: UK Police
+DLUHC:
+  hyphenated_name: department-for-levelling-up-housing-and-communities
+  name: Department for Levelling Up, Housing and Communities
+Defra:
+  hyphenated_name: defra
+  name: Department for Environment, Food and Rural Affairs
+BCC:
+  hyphenated_name: buckinghamshire-council
+  name: Buckinghamshire Council
+IS:
+ hyphenated_name: Insolvency-service
+name: Insolvency Service
+HO:
+  hyphenated_name: home-office
+  name: Home Office
+DfT:
+  hyphenated_name: department-for-transport
+  name: Department for Transport
+TAS:
+  hyphenated_name: the-apprenticeship-service
+  name: The Apprenticeship Service
+Cefas:
+  hyphenated_name: cefas
+  name: Centre for Environment, Fisheries and Aquaculture
+BGS:
+  hyphenated_name: bgs
+  name: British Geological Survey
+HMLR:
+  hyphenated_name: hm-land-registry
+  name: HM Land Registry
+DHSC:
+  hyphenated_name: department-for-health-and-social-care
+  name: Department for Health and Social Care
+CO:
+  hyphenated_name: cabinet-office
+  name: Cabinet Office

--- a/db/seeds/software_instances.csv
+++ b/db/seeds/software_instances.csv
@@ -1,9 +1,7 @@
 organisation,sub_organisation,team,owner,name,product,provider,packages,version,provider_contact,description,status,internal,license,quantity_purchased,quantity_used
-Department for Work and Pensions,,,,,Informatica,Infomatica,"Axon, MDM, PowerCentre, Data Quality AE, ",,,"Informatica 2021 licensing and support renewal (12 months) Informatica supply, support and maintain software products and tools that facilitate the integration of data and the management of that data, where the data has multiple sources and is in multiple formats. This data compilation supports the creation of management reports used by Ministers and throughout the wider DWP.",Live,Internal,,,
-Department for Education,,,,,Informatica,Infomatica,,,,Purchase of subscription to Informatica products for deployment in private cloud.,Live,Internal,,,
-Home Office,,,,,Collibra,Collibra,,,,"Collibra Licences 12 month with option to extend for a further 12 months.
-
-",Ended (March 2020),Internal,,,
-Cabinet Office,GDS,,,,Palantir,Palantir,,,,Enterprise Analytical Platform and Intelligence Service.,Ended (Aug 2017),Internal,,,
-Department for Health and Social Care,,Adult Social Care Dashboard,,,EDGE,,,,,,Live,,,,
-Department for Health and Social Care,,,,,Palantir,Palantir,,,,Provision of data management platform services,Ended (Sept 2020),Internal,,,
+DWP,,,,,Informatica,Infomatica,"Axon, MDM, PowerCentre, Data Quality AE, ",,,"Informatica 2021 licensing and support renewal (12 months) Informatica supply, support and maintain software products and tools that facilitate the integration of data and the management of that data, where the data has multiple sources and is in multiple formats. This data compilation supports the creation of management reports used by Ministers and throughout the wider DWP.",Live,Internal,,,
+DfE,,,,,Informatica,Infomatica,,,,Purchase of subscription to Informatica products for deployment in private cloud.,Live,Internal,,,
+HO,,,,,Collibra,Collibra,,,,"Collibra Licences 12 month with option to extend for a further 12 months.",Ended (March 2020),Internal,,,
+CO,GDS,,,,Palantir,Palantir,,,,Enterprise Analytical Platform and Intelligence Service.,Ended (Aug 2017),Internal,,,
+DHSC,,Adult Social Care Dashboard,,,EDGE,,,,,,Live,,,,
+DHSC,,,,,Palantir,Palantir,,,,Provision of data management platform services,Ended (Sept 2020),Internal,,,

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -3,4 +3,4 @@ admin@example.com:
   admin: true
 user@example.com:
   password: <%= Rails.application.credentials.seeds.password %>
-  organisation_id: <%= Organisation.find_or_create_by(name: 'Department for Health and Social Care').id %>
+  organisation_id: <%= Organisation.find_or_create_by(name: 'Department for Health and Social Care', tag: 'dhsc').id %>

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :organisation do
     name { Faker::Company.name }
+    tag { Faker::Lorem.characters(number: 10) }
   end
 end

--- a/spec/fixtures/organisations.yml
+++ b/spec/fixtures/organisations.yml
@@ -1,4 +1,6 @@
 foo:
   name: Foo
+  tag: foo
 bar:
   name: Bar
+  tag: bar

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:organisation) { build :organisation }
+
+  describe '#tag' do
+    it 'is valid if just letters' do
+      organisation.tag = 'abc'
+      expect(organisation).to be_valid
+    end
+
+    it 'is valid if letters, numbers, hyphens, and underscores' do
+      organisation.tag = 'a-1_B'
+      expect(organisation).to be_valid
+    end
+
+    it 'is not valid with spaces' do
+      organisation.tag = 'a 1_B'
+      expect(organisation).to be_invalid
+    end
+
+    it 'is not valid with leading hyphen' do
+      organisation.tag = '-abc'
+      expect(organisation).to be_invalid
+    end
+
+    it 'is not valid with leading underscore' do
+      organisation.tag = '_abc'
+      expect(organisation).to be_invalid
+    end
+
+    it 'is not valid with trailing hyphen' do
+      organisation.tag = 'abc-'
+      expect(organisation).to be_invalid
+    end
+
+    it 'is not valid with trailing underscore' do
+      organisation.tag = 'abc_'
+      expect(organisation).to be_invalid
+    end
+  end
 end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe "/organisations", type: :request do
-  fixtures :users
+  fixtures :users, :organisations
 
   let(:valid_attributes) do
-    { name: 'Something new' }
+    { name: 'Something new', tag: 'something-new' }
   end
 
   let(:invalid_attributes) do
-    { name: nil }
+    { name: '' }
   end
 
   let(:admin) { fixture :user, :admin }
@@ -21,7 +21,7 @@ RSpec.describe "/organisations", type: :request do
 
   describe "GET /index" do
     it "renders a successful response" do
-      Organisation.create! valid_attributes
+      organisation
       get organisations_url
       expect(response).to be_successful
     end
@@ -59,9 +59,9 @@ RSpec.describe "/organisations", type: :request do
           }.to change(Organisation, :count).by(1)
         end
 
-        it "redirects to the created organisation" do
+        it "redirects to the created organisation's software page" do
           post organisations_url, params: { organisation: valid_attributes }
-          expect(response).to redirect_to(organisation_url(Organisation.last))
+          expect(response).to redirect_to(organisation_software_instances_path(Organisation.last))
         end
       end
 
@@ -129,7 +129,7 @@ RSpec.describe "/organisations", type: :request do
         it "redirects to the organisation" do
           patch organisation_url(organisation), params: { organisation: new_attributes }
           organisation.reload
-          expect(response).to redirect_to(organisation_url(organisation))
+          expect(response).to redirect_to(organisation_software_instances_path(organisation))
         end
       end
 
@@ -153,7 +153,7 @@ RSpec.describe "/organisations", type: :request do
       it "redirects to the organisation" do
         patch organisation_url(organisation), params: { organisation: new_attributes }
         organisation.reload
-        expect(response).to redirect_to(organisation_url(organisation))
+        expect(response).to redirect_to(organisation_software_instances_path(organisation))
       end
     end
   end


### PR DESCRIPTION
Updates the organisations to use a tag as identify for app urls.

For example:

![organisation_tag](https://user-images.githubusercontent.com/119297020/211054219-53908444-4a7d-4fab-9bcc-5ea8bc41f7b2.png)

Also included:
- Ability to set tag on organisation creation (but not update)
- Update to seeds, fixtures and factories to accomodate tags.
- Validation of tag to ensure user entered tags will result in valid urls.
- Lookup table (`db/seeds/organisations.yml`) of known organisations used in creation. Seeding is configured to only create an organisation if seeds exist for matching software instances.
- Update to render configuration to reset database on build